### PR TITLE
[feat]몬스터 드랍 기능 개선

### DIFF
--- a/Text2DBattleGame/Characters.cs
+++ b/Text2DBattleGame/Characters.cs
@@ -323,8 +323,9 @@ namespace Text2DBattleGame
         {
             Hp -= damage;
         }
-        static public IItem Drop(List<IItem> droptable)
+        static public IItem Drop(List<IItem> droptable1)
         {
+            List<IItem> droptable = droptable1;
             int persent = 100; //드랍확률
             Random random = new Random();
             int basic = random.Next(1, 100);
@@ -336,7 +337,7 @@ namespace Text2DBattleGame
             }
             return null;
         }
-    
+
     }
     public class Minion : Monster
     {

--- a/Text2DBattleGame/DisplayBattle.cs
+++ b/Text2DBattleGame/DisplayBattle.cs
@@ -10,7 +10,9 @@ namespace Text2DBattleGame
     class DisplayBattle
     {
         
-        static List<IItem> itemTable1 = new List<IItem>() { new AttackItem("test","test",true,1,1,1,1,'a'), new PotionItem("테스트 모능물약", "테스트", false, 1, 1, 1, 1,'p')  };
+        public static List<IItem> itemTable1 = new List<IItem>();
+
+        public static List<IItem> testTabel = new List<IItem>() { new AttackItem("test", "test", true, 1, 1, 1, 1, 'a'), new PotionItem("테스트 모능물약", "테스트", false, 1, 1, 1, 1, 'p') };
         public static void Display(Character player)
         {
             int gold = player.Gold;
@@ -140,7 +142,7 @@ namespace Text2DBattleGame
                     {
                         if (player.Mp >= player.Skills[skillNum - 1].Mp)
                         {
-                            player.Skills[skillNum - 1].UsingSkill(player, battleMonsters, player.Skills[skillNum - 1].Mp);
+                            player.Skills[skillNum - 1].UsingSkill(player, battleMonsters, player.Skills[skillNum - 1].Mp, itemTable1);
                             break;
                         }
                         else
@@ -239,6 +241,8 @@ namespace Text2DBattleGame
             if (defender.IsDead)
             {
                 Console.WriteLine("Dead");
+                itemTable1 = changeDropTabel(defender);//디펜더=죽은 몬스터 = 죽은몬스터의 이름을받아 몬스터등급별 테이블로 이동
+
                 getItem.Add(Monster.Drop(itemTable1));
                 attacker.Exp += defender.Level;//경험치추가
                 attacker.Gold += defender.Gold;//골드추가
@@ -249,7 +253,7 @@ namespace Text2DBattleGame
             }
         }
 
-        public static void SkillAttack(Character attacker, List<Monster> defenders, int damage)
+        public static void SkillAttack(Character attacker, List<Monster> defenders, int damage, List<IItem> getItem)
         {
             //반복문 안에서 계속 같은수뱉어서 빼냄
             Random rand = new Random();
@@ -282,7 +286,8 @@ namespace Text2DBattleGame
                 if (defenders[i].IsDead)
                 {
                     Console.WriteLine("Dead");
-                    Monster.Drop(itemTable1);
+                    //Monster.Drop(itemTable1); 드랍은 아이템을 생성하는 함수
+                    getItem.Add(Monster.Drop(itemTable1));
                     attacker.Exp += defenders[i].Level;//경험치추가
                     attacker.Gold += defenders[i].Gold;//골드추가
 
@@ -295,7 +300,42 @@ namespace Text2DBattleGame
                 Console.WriteLine();
             }
         }
+        public static List<IItem> changeDropTabel(ICharacter character) 
+        {
+            switch (character.Name)
+            {
+                case "미니언":
+                    return testTabel;    
+                    
+                case "공허충":
+                    return testTabel;
 
+                case "대포미니언":
+                    return testTabel;
+ 
+
+                case "타락한 거미":
+                    return testTabel;
+                    
+
+                case "그림자속무언가":
+                    return testTabel;
+
+                case "타락한 거미여왕":
+                    return testTabel;
+
+                case "수중뱀":
+                    return testTabel;
+
+                case "수중서펀트":
+                    return testTabel;
+
+                case "드래곤":
+                    return testTabel;
+                default:
+                    return testTabel;
+            }
+        }
 
         public static void WriteBattle()
         {

--- a/Text2DBattleGame/Skill.cs
+++ b/Text2DBattleGame/Skill.cs
@@ -16,7 +16,7 @@ namespace Text2DBattleGame
 
         public Func<Character, string> ShowExplanation { get; set; }
 
-        public Action<Character, Monster[], int> UsingSkill { get; set; }
+        public Action<Character, Monster[], int, List<IItem>> UsingSkill { get; set; }
 
         public Skill(string name, int atk, int mp)
         {

--- a/Text2DBattleGame/SkillManager.cs
+++ b/Text2DBattleGame/SkillManager.cs
@@ -29,7 +29,7 @@ namespace Text2DBattleGame
             return skills;
         }
 
-        private void Warrior_AlphaStrike(Character player, Monster[] monsters, int useMp)
+        private void Warrior_AlphaStrike(Character player, Monster[] monsters, int useMp, List<IItem> itemTable1)
         {
             //원본
             //monsters[new Random().Next(0, monsters.Length)].TakeDamage((int)(player.Atk * 2f));
@@ -83,13 +83,13 @@ namespace Text2DBattleGame
 
             DisplayBattle.WriteBattle();
 
-            DisplayBattle.SkillAttack(player, hitMobs, (int)(player.Atk * 2f));
+            DisplayBattle.SkillAttack(player, hitMobs, (int)(player.Atk * 2f), itemTable1);
 
 
             // 구조상 차라리 Display Battle을 매니저처럼 쓰는게 좋을것 같아 위처럼 했습니다.
         }
 
-        private void Warrior_DoubleStrike(Character player, Monster[] monsters, int useMp)
+        private void Warrior_DoubleStrike(Character player, Monster[] monsters, int useMp, List<IItem> itemTable1)
         {
             /*
             List<int> randomNums = new List<int>();
@@ -139,7 +139,7 @@ namespace Text2DBattleGame
 
             DisplayBattle.WriteBattle();
 
-            DisplayBattle.SkillAttack(player, hitMobs, (int)(player.Atk * 1.5f));
+            DisplayBattle.SkillAttack(player, hitMobs, (int)(player.Atk * 1.5f), itemTable1);
         }
 
         #endregion
@@ -165,7 +165,7 @@ namespace Text2DBattleGame
             return skills;
         }
 
-        private void Wizard_FireBall(Character player, Monster[] monsters, int useMp)
+        private void Wizard_FireBall(Character player, Monster[] monsters, int useMp, List<IItem> itemTable1)
         {
             player.UsingMp(useMp);
 
@@ -216,10 +216,10 @@ namespace Text2DBattleGame
 
             DisplayBattle.WriteBattle();
 
-            DisplayBattle.SkillAttack(player, hitMobs, (int)(player.Atk * 3f));
+            DisplayBattle.SkillAttack(player, hitMobs, (int)(player.Atk * 3f), itemTable1);
         }
 
-        private void Wizard_Meteor(Character player, Monster[] monsters, int useMp)
+        private void Wizard_Meteor(Character player, Monster[] monsters, int useMp, List<IItem> itemTable1)
         {
             player.UsingMp(useMp);
 
@@ -248,7 +248,7 @@ namespace Text2DBattleGame
 
             DisplayBattle.WriteBattle();
 
-            DisplayBattle.SkillAttack(player, hitMobs, (int)(player.Atk * 1.0f));
+            DisplayBattle.SkillAttack(player, hitMobs, (int)(player.Atk * 1.0f), itemTable1);
         }
 
         #endregion


### PR DESCRIPTION
스킬로 몬스터를 죽일시 아이템이 드랍되지 않는 버그 개선
아이템 테이블의 의도가 몬스터 마다 강함의 등급 상 중 하 가 있다고 할때 하 등급  몬스터를 잡으면 아이템 테이블 하 로 연결 - 그러나 아이템 갯수 테이블 조정이 없어서 기능만 구현된 상태